### PR TITLE
Add expression in match target

### DIFF
--- a/examples/control-flow.ink
+++ b/examples/control-flow.ink
@@ -32,6 +32,16 @@ device :: {
 '
     },
     {
+        docs: 'A match target can be an expression.'
+        code: 'greeting := \'Hello!\'
+greeting :: {
+    \'Hello\' -> log(\'They greeted us.\')
+    \'Hello\' + \'!\' -> log(\'They greeted us loudly.\')
+}
+
+'
+    },
+    {
         docs: 'Composite values are deep compared so the underscore can be used to catch complex objects that, while different, have a similar characteristic.'
         code: 'first := {
     code: 2,

--- a/examples/hello-world.ink
+++ b/examples/hello-world.ink
@@ -27,7 +27,4 @@ a multi-line comment
     }
 ]
 
-
-
-
 end := 'To run the program, put the code in <code>hello-world.ink</code> and run it with the interpreter.'

--- a/static/site.css
+++ b/static/site.css
@@ -88,8 +88,6 @@ p.footer a, p.footer a:visited {
     color: grey;
 }
 div#intro {
-    width: 420px;
-    min-width: 420px;
     max-width: 420px;
     margin-left: auto;
     margin-right: auto;

--- a/vendor/quicksort.ink
+++ b/vendor/quicksort.ink
@@ -11,18 +11,18 @@ sortBy := (v, pred) => (
 	vPred := map(v, pred)
 	partition := (v, lo, hi) => (
 		pivot := vPred.(lo)
-		lsub := i => (vPred.(i) < pivot) :: {
+		lsub := i => vPred.(i) < pivot :: {
 			true -> lsub(i + 1)
 			false -> i
 		}
-		rsub := j => (vPred.(j) > pivot) :: {
+		rsub := j => vPred.(j) > pivot :: {
 			true -> rsub(j - 1)
 			false -> j
 		}
 		(sub := (i, j) => (
 			i := lsub(i)
 			j := rsub(j)
-			(i < j) :: {
+			i < j :: {
 				false -> j
 				true -> (
 					` inlined swap! `
@@ -40,7 +40,7 @@ sortBy := (v, pred) => (
 	)
 	(quicksort := (v, lo, hi) => len(v) :: {
 		0 -> v
-		_ -> (lo < hi) :: {
+		_ -> lo < hi :: {
 			false -> v
 			true -> (
 				p := partition(v, lo, hi)

--- a/vendor/std.ink
+++ b/vendor/std.ink
@@ -133,10 +133,10 @@ clone := x => type(x) :: {
 stringList := list => '[' + cat(map(list, string), ', ') + ']'
 
 ` tail recursive reversing a list `
-reverse := list => (sub := (acc, i, j) => j :: {
-	0 -> acc.(i) := list.0
-	_ -> sub(acc.(i) := list.(j), i + 1, j - 1)
-})([], 0, len(list) - 1)
+reverse := list => (sub := (acc, i) => i < 0 :: {
+	true -> acc
+	_ -> sub(acc.len(acc) := list.(i), i - 1)
+})([], len(list) - 1)
 
 ` tail recursive map `
 map := (list, f) => reduce(list, (l, item, i) => l.(i) := f(item, i), {})


### PR DESCRIPTION
https://github.com/thesephist/ink/releases/tag/v0.1.9

> Ink 1.9 allows expressions in the match target position of a match clause

Include this syntax as one of the sections on the Control Flow page.